### PR TITLE
Adding yargs and support for -p,--profile to use named profiles in .aws/credentials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,5 @@ typings/
 
 # build / generate output
 dist
+
+.envrc

--- a/index.js
+++ b/index.js
@@ -18,15 +18,16 @@ const TTL_SECONDS = 43200;
 // https://aws.amazon.com/code/aws-management-console-federation-proxy-sample-use-case/
 
 function doLogin(profile) {
-  /*
-  The following AWS STS API call creates a temporary session that returns 
-  a temporary security credentials and a session token. 
-  The policy grants permissions to the AWS management console.
-*/
   if (profile) {
     const credentials = new AWS.SharedIniFileCredentials({ profile });
     AWS.config.credentials = credentials;
   }
+
+  /*
+    The following AWS STS API call creates a temporary session that returns 
+    a temporary security credentials and a session token. 
+    The policy grants permissions to the AWS management console.
+  */
   const sts = new AWS.STS();
 
   const federationTokenParams = {
@@ -51,11 +52,11 @@ function doLogin(profile) {
       console.error(err);
     } else {
       /* 
-      On successful response from the aws sdk, we call the federation endpoint, 
-      passing the parameters created earlier and the session information as a JSON block. 
-      The request returns a sign-in token that's valid for 15 minutes. Signing in to 
-      the console with the token creates a session that is valid for 12 hours.
-    */
+        On successful response from the aws sdk, we call the federation endpoint, 
+        passing the parameters created earlier and the session information as a JSON block. 
+        The request returns a sign-in token that's valid for 15 minutes. Signing in to 
+        the console with the token creates a session that is valid for 12 hours.
+      */
       const requestParams = {
         Action: "getSigninToken",
         DurationSeconds: TTL_SECONDS,
@@ -73,11 +74,11 @@ function doLogin(profile) {
           if (resp && resp.status === 200 && resp.data) {
             if (resp.data.SigninToken) {
               /*
-            Once we have a sign-in token returned by the federation endpoint,
-            We then create the URL to open in the browser, which includes the
-            sign-in token and the URL of the console to open, The "issuer" parameter is optional but 
-            we are not using it since there is no custom identity broker, and we just using our cmd line
-          */
+        Once we have a sign-in token returned by the federation endpoint,
+        We then create the URL to open in the browser, which includes the
+        sign-in token and the URL of the console to open, The "issuer" parameter is optional but 
+        we are not using it since there is no custom identity broker, and we just using our cmd line
+      */
               const loginUrl = new URL(SIGNIN_URL);
               loginUrl.searchParams.append("Action", "login");
               loginUrl.searchParams.append("Destination", CONSOLE_URL);
@@ -102,9 +103,13 @@ const pkg = require("./package.json");
 
 const argv = require("yargs")
   .usage("Usage: $0 [-p profile_name]")
+  .option("profile", {
+    alias: "p",
+    type: "string",
+    description: "Use named profile in .aws/credentials",
+  })
   .version(pkg.version)
   .help("h")
-  .alias("h", "help")
-  .alias("p", "profile").argv;
+  .alias("h", "help").argv;
 
 doLogin(argv.profile);

--- a/index.js
+++ b/index.js
@@ -4,90 +4,107 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-'use strict';
+"use strict";
 
-const AWS   = require('aws-sdk');
-const axios = require('axios');
-const open  = require('open');
+const AWS = require("aws-sdk");
+const axios = require("axios");
+const open = require("open");
 
-const SIGNIN_URL  = 'https://signin.aws.amazon.com/federation';
-const CONSOLE_URL = 'https://console.aws.amazon.com/';
+const SIGNIN_URL = "https://signin.aws.amazon.com/federation";
+const CONSOLE_URL = "https://console.aws.amazon.com/";
 const TTL_SECONDS = 43200;
 
 // https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_enable-console-custom-url.html
 // https://aws.amazon.com/code/aws-management-console-federation-proxy-sample-use-case/
 
-/*
+function doLogin(profile) {
+  /*
   The following AWS STS API call creates a temporary session that returns 
   a temporary security credentials and a session token. 
   The policy grants permissions to the AWS management console.
 */
-const sts = new AWS.STS();
+  if (profile) {
+    const credentials = new AWS.SharedIniFileCredentials({ profile });
+    AWS.config.credentials = credentials;
+  }
+  const sts = new AWS.STS();
 
-const federationTokenParams = {
-  Name: 'TempUserSession',
-  DurationSeconds: TTL_SECONDS,
-  Policy: JSON.stringify({
-    Version: '2012-10-17', 
-    Statement: [
-      {
-        Effect: 'Allow',
-        Action: '*',
-        Resource: '*'
-      }
-    ]
-  })
-};
+  const federationTokenParams = {
+    Name: "TempUserSession",
+    DurationSeconds: TTL_SECONDS,
+    Policy: JSON.stringify({
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Effect: "Allow",
+          Action: "*",
+          Resource: "*",
+        },
+      ],
+    }),
+  };
 
-sts.getFederationToken(federationTokenParams, (err, data) => {
-  const defaultErrorMsg = 'Oops, something went wrong. It seems like the call to the federation endpoint did fail';
-  if (err) {
-    // an error occurred
-    console.error(err);    
-  } 
-  else {
-    /* 
+  sts.getFederationToken(federationTokenParams, (err, data) => {
+    const defaultErrorMsg = "Oops, something went wrong. It seems like the call to the federation endpoint did fail";
+    if (err) {
+      // an error occurred
+      console.error(err);
+    } else {
+      /* 
       On successful response from the aws sdk, we call the federation endpoint, 
       passing the parameters created earlier and the session information as a JSON block. 
       The request returns a sign-in token that's valid for 15 minutes. Signing in to 
       the console with the token creates a session that is valid for 12 hours.
     */
-    const requestParams = {
-      Action: 'getSigninToken',
-      DurationSeconds: TTL_SECONDS,
-      SessionType: 'json',
-      Session: {
-        sessionId: data.Credentials.AccessKeyId,
-        sessionKey: data.Credentials.SecretAccessKey,
-        sessionToken: data.Credentials.SessionToken
-      }
-    }
-    axios.get(SIGNIN_URL, {params: requestParams } ).then((resp) => {
-      // handle success
-      if (resp && resp.status === 200 && resp.data) {
-        if (resp.data.SigninToken) {
-          /*
+      const requestParams = {
+        Action: "getSigninToken",
+        DurationSeconds: TTL_SECONDS,
+        SessionType: "json",
+        Session: {
+          sessionId: data.Credentials.AccessKeyId,
+          sessionKey: data.Credentials.SecretAccessKey,
+          sessionToken: data.Credentials.SessionToken,
+        },
+      };
+      axios
+        .get(SIGNIN_URL, { params: requestParams })
+        .then(resp => {
+          // handle success
+          if (resp && resp.status === 200 && resp.data) {
+            if (resp.data.SigninToken) {
+              /*
             Once we have a sign-in token returned by the federation endpoint,
             We then create the URL to open in the browser, which includes the
             sign-in token and the URL of the console to open, The "issuer" parameter is optional but 
             we are not using it since there is no custom identity broker, and we just using our cmd line
           */
-          const loginUrl = new URL(SIGNIN_URL);
-          loginUrl.searchParams.append('Action', 'login');
-          loginUrl.searchParams.append('Destination', CONSOLE_URL);
-          loginUrl.searchParams.append('SigninToken', resp.data.SigninToken);
-          open(loginUrl.href);
-        } else {
-          console.error(`${defaultErrorMsg}. No 'SigninToken' value is returned, please try again.`);
-        }
-      } else {
-        console.error(`${defaultErrorMsg}, please try again.`);
-      }
-    }).catch((err) => {
-      // an error occurred
-      console.error(`${defaultErrorMsg}, Error: ${err}`);
-    });
-  }
-});
+              const loginUrl = new URL(SIGNIN_URL);
+              loginUrl.searchParams.append("Action", "login");
+              loginUrl.searchParams.append("Destination", CONSOLE_URL);
+              loginUrl.searchParams.append("SigninToken", resp.data.SigninToken);
+              open(loginUrl.href);
+            } else {
+              console.error(`${defaultErrorMsg}. No 'SigninToken' value is returned, please try again.`);
+            }
+          } else {
+            console.error(`${defaultErrorMsg}, please try again.`);
+          }
+        })
+        .catch(err => {
+          // an error occurred
+          console.error(`${defaultErrorMsg}, Error: ${err}`);
+        });
+    }
+  });
+}
 
+const pkg = require("./package.json");
 
+const argv = require("yargs")
+  .usage("Usage: $0 [-p profile_name]")
+  .version(pkg.version)
+  .help("h")
+  .alias("h", "help")
+  .alias("p", "profile").argv;
+
+doLogin(argv.profile);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aws-console",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "minayousseif",
   "license": "MIT",
   "engines": {
@@ -31,7 +31,8 @@
   "dependencies": {
     "aws-sdk": "^2.596.0",
     "axios": "^0.19.0",
-    "open": "^7.0.0"
+    "open": "^7.0.0",
+    "yargs": "^15.1.0"
   },
   "repository": {
     "type": "git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,24 @@
 # yarn lockfile v1
 
 
+"@types/color-name@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
+  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
+
+ansi-regex@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
+  integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+
+ansi-styles@^4.0.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
+  integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
+  dependencies:
+    "@types/color-name" "^1.1.1"
+    color-convert "^2.0.1"
+
 aws-sdk@^2.596.0:
   version "2.596.0"
   resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.596.0.tgz#1a4af0609e174a50ffb8ed8981981e6d77a614fb"
@@ -39,6 +57,32 @@ buffer@4.9.1:
     ieee754 "^1.1.4"
     isarray "^1.0.0"
 
+camelcase@^5.0.0:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
+  integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
+cliui@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/cliui/-/cliui-6.0.0.tgz#511d702c0c4e41ca156d7d0e96021f23e13225b1"
+  integrity sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
+  dependencies:
+    string-width "^4.2.0"
+    strip-ansi "^6.0.0"
+    wrap-ansi "^6.2.0"
+
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-2.0.1.tgz#72d3a68d598c9bdb3af2ad1e84f21d896abd4de3"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
 debug@=3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
@@ -46,10 +90,28 @@ debug@=3.1.0:
   dependencies:
     ms "2.0.0"
 
+decamelize@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
+  integrity sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
+
+emoji-regex@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
+  integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+
 events@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/events/-/events-1.1.1.tgz#9ebdb7635ad099c70dcc4c2a1f5004288e8bd924"
   integrity sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=
+
+find-up@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
+  integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
+  dependencies:
+    locate-path "^5.0.0"
+    path-exists "^4.0.0"
 
 follow-redirects@1.5.10:
   version "1.5.10"
@@ -57,6 +119,11 @@ follow-redirects@1.5.10:
   integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
   dependencies:
     debug "=3.1.0"
+
+get-caller-file@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
+  integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
 ieee754@1.1.13, ieee754@^1.1.4:
   version "1.1.13"
@@ -67,6 +134,11 @@ is-buffer@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.4.tgz#3e572f23c8411a5cfd9557c849e3665e0b290623"
   integrity sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==
+
+is-fullwidth-code-point@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz#f116f8064fe90b3f7844a38997c0b75051269f1d"
+  integrity sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
 
 is-wsl@^2.1.0:
   version "2.1.1"
@@ -83,6 +155,13 @@ jmespath@0.15.0:
   resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
   integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
 
+locate-path@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-5.0.0.tgz#1afba396afd676a6d42504d0a67a3a7eb9f62aa0"
+  integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
+  dependencies:
+    p-locate "^4.1.0"
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -95,6 +174,30 @@ open@^7.0.0:
   dependencies:
     is-wsl "^2.1.0"
 
+p-limit@^2.2.0:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.2.tgz#61279b67721f5287aa1c13a9a7fbbc48c9291b1e"
+  integrity sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==
+  dependencies:
+    p-try "^2.0.0"
+
+p-locate@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-4.1.0.tgz#a3428bb7088b3a60292f66919278b7c297ad4f07"
+  integrity sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
+  dependencies:
+    p-limit "^2.2.0"
+
+p-try@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
+  integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
 punycode@1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-1.3.2.tgz#9653a036fb7c1ee42342f2325cceefea3926c48d"
@@ -105,6 +208,16 @@ querystring@0.2.0:
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
 
+require-directory@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/require-directory/-/require-directory-2.1.1.tgz#8c64ad5fd30dab1c976e2344ffe7f792a6a6df42"
+  integrity sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+
+require-main-filename@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
+  integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
 sax@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
@@ -114,6 +227,27 @@ sax@>=0.6.0:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
+
+set-blocking@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
+  integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
+string-width@^4.1.0, string-width@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
+  integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.0"
+
+strip-ansi@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.0.tgz#0b1571dd7669ccd4f3e06e14ef1eed26225ae532"
+  integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
+  dependencies:
+    ansi-regex "^5.0.0"
 
 url@0.10.3:
   version "0.10.3"
@@ -128,6 +262,20 @@ uuid@3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
+which-module@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
+  integrity sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
+
+wrap-ansi@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 xml2js@0.4.19:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.4.19.tgz#686c20f213209e94abf0d1bcf1efaa291c7827a7"
@@ -140,3 +288,33 @@ xmlbuilder@~9.0.1:
   version "9.0.7"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz#132ee63d2ec5565c557e20f4c22df9aca686b10d"
   integrity sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=
+
+y18n@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
+  integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
+
+yargs-parser@^16.1.0:
+  version "16.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-16.1.0.tgz#73747d53ae187e7b8dbe333f95714c76ea00ecf1"
+  integrity sha512-H/V41UNZQPkUMIT5h5hiwg4QKIY1RPvoBV4XcjUbRM8Bk2oKqqyZ0DIEbTFZB0XjbtSPG8SAa/0DxCQmiRgzKg==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
+yargs@^15.1.0:
+  version "15.1.0"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.1.0.tgz#e111381f5830e863a89550bd4b136bb6a5f37219"
+  integrity sha512-T39FNN1b6hCW4SOIk1XyTOWxtXdcen0t+XYrysQmChzSipvhBO8Bj0nK1ozAasdk24dNWuMZvr4k24nz+8HHLg==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^16.1.0"


### PR DESCRIPTION
This add support for named profiles.

Sorry about the formatting change -- vscode + prettier are insistent.  I tried to revert and go back to your format, but turning the main code into a function hit almost every line anyway.

Example: 
```
$ ./bin/aws-console -h
Usage: aws-console [-p profile_name]

Options:
  --profile, -p  Use named profile in .aws/credentials                  [string]
  --version      Show version number                                   [boolean]
  -h, --help     Show help                                             [boolean]

$ ./bin/aws-console --version
1.0.3
```